### PR TITLE
[WIP] Qt5patch from Gentoo

### DIFF
--- a/res/barrier.desktop
+++ b/res/barrier.desktop
@@ -1,6 +1,5 @@
 [Desktop Entry]
 Type=Application
-Version=2.1
 Name=Barrier
 Comment=Keyboard and mouse sharing solution
 Exec=barrier

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -22,7 +22,7 @@ add_executable (barrier WIN32
 
 include_directories (./src)
 
-qt5_use_modules (barrier Core Widgets Network)
+target_link_libraries (barrier QT5::Core QT5::Widgets QT5::Network)
 target_compile_definitions (barrier PRIVATE -DBARRIER_VERSION_STAGE="${BARRIER_VERSION_STAGE}")
 target_compile_definitions (barrier PRIVATE -DBARRIER_REVISION="${BARRIER_REVISION}")
 

--- a/src/gui/src/ActionDialog.cpp
+++ b/src/gui/src/ActionDialog.cpp
@@ -25,6 +25,7 @@
 
 #include <QtCore>
 #include <QtGui>
+#include <QButtonGroup>
 
 ActionDialog::ActionDialog(QWidget* parent, ServerConfig& config, Hotkey& hotkey, Action& action) :
     QDialog(parent, Qt::WindowTitleHint | Qt::WindowSystemMenuHint),

--- a/src/gui/src/ScreenSetupView.cpp
+++ b/src/gui/src/ScreenSetupView.cpp
@@ -22,6 +22,7 @@
 
 #include <QtCore>
 #include <QtGui>
+#include <QHeaderView>
 
 ScreenSetupView::ScreenSetupView(QWidget* parent) :
     QTableView(parent)


### PR DESCRIPTION
This PR should *not* be merged as it clearly is a fix for those systems with QT5 but breaks qt4 based systems. I am not familiar enough with QT and CMake ecosystem to know how to correctly IFFT this inside either QMake or some other place.

In issue #49 a patch at Gentoo was identified to fix QT5 build issues. 

https://gitweb.gentoo.org/repo/gentoo.git/plain/x11-misc/synergy/files/synergy-1.9.1-qt-5.11.patch?id=5dd1f7a3908dec9ae6cf6773acd8ec3b33fc0b2c

Currently this patch breaks build on an Ubuntu 16.04 system. 

---

Credit for that patch goes to Andreas Sturmlechner @ Gentoo

https://gitweb.gentoo.org/repo/gentoo.git/commit/?id=5dd1f7a3908dec9ae6cf6773acd8ec3b33fc0b2c

Patch is distributed under the terms of the GNU General Public License v2 meaning it is compatible for the purposes here.  https://gitweb.gentoo.org/repo/gentoo.git/plain/header.txt

